### PR TITLE
Refactor Point (and derived interfaces) inheritance

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -144,7 +144,7 @@ To add the Pseudonymisation Helper library in your project, you can add this Mav
 <dependency>
   <groupId>be.smals.shared.pseudo</groupId>
   <artifactId>pseudo-helper</artifactId>
-  <version>0.1.0</version>
+  <version>1.0.0</version>
 </dependency>
 ----
 
@@ -849,12 +849,12 @@ A PseudonymInTransit object represents a pseudonymInTransit that contains a Pseu
   Pseudonym atRest(boolean validateIatAndExp) throws InvalidTransitInfoException;
 
   /**
-   * Returns {@code this} because it is already a {@link PseudonymInTransit}.
+   * Convert this {@link PseudonymInTransit} into a {@link PseudonymInTransit} for the given domain.
    *
-   * @return this
+   * @param toDomain the target domain for the returned {@link PseudonymInTransit}
+   * @return a {@link PseudonymInTransit} for the given domain, matching this {@link PseudonymInTransit}
    */
-  @Override
-  PseudonymInTransit inTransit();
+  CompletableFuture<? extends PseudonymInTransit> convertTo(Domain toDomain);
 ----
 
 == Use of PseudonymisationHelper in real use cases

--- a/src/main/java/be/smals/shared/pseudo/helper/Point.java
+++ b/src/main/java/be/smals/shared/pseudo/helper/Point.java
@@ -8,4 +8,18 @@ public interface Point {
    * @return the domain that owns this point
    */
   Domain domain();
+
+  /**
+   * Returns binary representation of the X coordinate (as a byte array converted in a Base64 String).
+   *
+   * @return binary representation of the X coordinate (as a byte array converted in a Base64 String)
+   */
+  String x();
+
+  /**
+   * Returns binary representation of the Y coordinate (as a byte array converted in a Base64 String).
+   *
+   * @return binary representation of the Y coordinate (as a byte array converted in a Base64 String)
+   */
+  String y();
 }

--- a/src/main/java/be/smals/shared/pseudo/helper/Pseudonym.java
+++ b/src/main/java/be/smals/shared/pseudo/helper/Pseudonym.java
@@ -10,24 +10,19 @@ public interface Pseudonym extends Point {
 
   // tag::methods[]
   /**
-   * Returns binary representation of the X coordinate (as a byte array converted in a Base64 String).
-   *
-   * @return binary representation of the X coordinate (as a byte array converted in a Base64 String)
-   */
-  String x();
-
-  /**
-   * Returns binary representation of the Y coordinate (as a byte array converted in a Base64 String).
-   *
-   * @return binary representation of the Y coordinate (as a byte array converted in a Base64 String)
-   */
-  String y();
-
-  /**
    * Base64 URL encoded uncompressed SEC1 Elliptic-Curve-Point-to-Octet-String Conversion of this point.
    *
    * @return Base64 URL encoded the uncompressed SEC1 Elliptic-Curve-Point-to-Octet-String Conversion of this point
    */
+  String asString();
+
+  /**
+   * Calls {@link #asString()}.
+   *
+   * @return String returned by {@link #asString()}
+   * @deprecated Please use {@link #asString()} instead.
+   */
+  @Deprecated(forRemoval = true)
   String sec1();
 
   /**
@@ -35,6 +30,15 @@ public interface Pseudonym extends Point {
    *
    * @return compressed SEC 1 representation of this point
    */
+  String asShortString();
+
+  /**
+   * Calls {@link #asShortString()}.
+   *
+   * @return String returned by {@link #asShortString()}
+   * @deprecated Please use {@link #asShortString()} instead.
+   */
+  @Deprecated(forRemoval = true)
   String sec1Compressed();
 
   /**

--- a/src/main/java/be/smals/shared/pseudo/helper/PseudonymInTransit.java
+++ b/src/main/java/be/smals/shared/pseudo/helper/PseudonymInTransit.java
@@ -1,14 +1,40 @@
 package be.smals.shared.pseudo.helper;
 
 import be.smals.shared.pseudo.helper.exceptions.InvalidTransitInfoException;
+import be.smals.shared.pseudo.helper.internal.PseudonymImpl;
 import java.util.concurrent.CompletableFuture;
 
 @SuppressWarnings("unused")
-public interface PseudonymInTransit extends Pseudonym {
+public interface PseudonymInTransit extends Point {
+
+  /**
+   * Base64 URL encoded uncompressed SEC1 Elliptic-Curve-Point-to-Octet-String Conversion of this point.
+   *
+   * @return Base64 URL encoded the uncompressed SEC1 Elliptic-Curve-Point-to-Octet-String Conversion of this point
+   * @deprecated Please call {@link #pseudonym()}.{@link Pseudonym#asString() asString()} instead.
+   */
+  @Deprecated(forRemoval = true)
+  String sec1();
+
+  /**
+   * Base64 URL encoded compressed SEC1 Elliptic-Curve-Point-to-Octet-String Conversion of this point.
+   *
+   * @return Base64 URL encoded the compressed SEC1 Elliptic-Curve-Point-to-Octet-String Conversion of this point
+   * @deprecated Please call {@link #pseudonym()}.{@link Pseudonym#asShortString() asString()} instead.
+   */
+  @Deprecated(forRemoval = true)
+  String sec1Compressed();
 
   // tag::methods[]
   /**
-   * Returns the {@link TransitInfo}.
+   * Returns the {@link Pseudonym} of this {@link PseudonymInTransit}.
+   *
+   * @return the {@link Pseudonym} of this {@link PseudonymInTransit}
+   */
+  PseudonymImpl pseudonym();
+
+  /**
+   * Returns the {@link TransitInfo} of this {@link PseudonymInTransit}.
    *
    * @return the {@link TransitInfo}
    */
@@ -68,11 +94,20 @@ public interface PseudonymInTransit extends Pseudonym {
   Pseudonym atRest(boolean validateIatAndExp) throws InvalidTransitInfoException;
 
   /**
+   * Convert this {@link PseudonymInTransit} into a {@link PseudonymInTransit} for the given domain.
+   *
+   * @param toDomain the target domain for the returned {@link PseudonymInTransit}
+   * @return a {@link PseudonymInTransit} for the given domain, matching this {@link PseudonymInTransit}
+   */
+  CompletableFuture<? extends PseudonymInTransit> convertTo(Domain toDomain);
+  // end::methods[]
+
+  /**
    * Returns {@code this} because it is already a {@link PseudonymInTransit}.
    *
    * @return this
+   * @deprecated This method returns {@code this}: there is no need to keep it.
    */
-  @Override
+  @Deprecated(forRemoval = true)
   PseudonymInTransit inTransit();
-  // end::methods[]
 }

--- a/src/main/java/be/smals/shared/pseudo/helper/Value.java
+++ b/src/main/java/be/smals/shared/pseudo/helper/Value.java
@@ -9,7 +9,24 @@ import java.util.concurrent.CompletableFuture;
 @SuppressWarnings("unused")
 public interface Value extends Point {
 
+  /**
+   * Should not be used in regular usage, but it can be convenient for testing/logging purpose.
+   *
+   * @see Point#x()
+   */
+  @Override
+  String x();
+
+  /**
+   * Should not be used in regular usage, but it can be convenient for testing/logging purpose.
+   *
+   * @see Point#y()
+   */
+  @Override
+  String y();
+
   // tag::methods[]
+
   /**
    * Returns the value as a bytes array.
    * <p>
@@ -48,7 +65,9 @@ public interface Value extends Point {
    * Should not be used in regular usage, but it can be convenient for testing/logging purpose.
    *
    * @return this {@link Value} as a {@link Pseudonym}.
+   * @deprecated It will be removed soon to avoid developpers to consider the value as a pseudonymized value.
    */
+  @Deprecated
   Pseudonym asPseudonym();
 
   /**

--- a/src/main/java/be/smals/shared/pseudo/helper/internal/MultiplePseudonymInTransitImpl.java
+++ b/src/main/java/be/smals/shared/pseudo/helper/internal/MultiplePseudonymInTransitImpl.java
@@ -53,7 +53,8 @@ public final class MultiplePseudonymInTransitImpl extends MultiplePointImpl<Pseu
     payload.add("inputs", inputs);
     for (int i = 0; i < nbPseudonymsInTransit; i++) {
       final var random = domain.createRandom();
-      inputs.add(domain.createPayload(((PseudonymInTransitImpl) points.get(i)).multiply(random)));
+      final var pseudonymInTransit = (PseudonymInTransitImpl) points.get(i);
+      inputs.add(domain.createPayload(pseudonymInTransit.pseudonym().multiply(random), pseudonymInTransit.transitInfo().asString()));
       randoms.add(random);
     }
     return domain.pseudonymisationClient()
@@ -102,7 +103,8 @@ public final class MultiplePseudonymInTransitImpl extends MultiplePointImpl<Pseu
     payload.add("inputs", inputs);
     for (int i = 0; i < nbPseudonymsInTransit; i++) {
       final var random = domain.createRandom();
-      inputs.add(domain.createPayload(((PseudonymInTransitImpl) points.get(i)).multiply(random)));
+      final var pseudonymInTransit = (PseudonymInTransitImpl) points.get(i);
+      inputs.add(domain.createPayload(pseudonymInTransit.pseudonym().multiply(random), pseudonymInTransit.transitInfo().asString()));
       randoms.add(random);
     }
     return domain.pseudonymisationClient()

--- a/src/main/java/be/smals/shared/pseudo/helper/internal/PseudonymImpl.java
+++ b/src/main/java/be/smals/shared/pseudo/helper/internal/PseudonymImpl.java
@@ -29,13 +29,25 @@ public class PseudonymImpl extends PointImpl implements Pseudonym {
   }
 
   @Override
-  public String sec1() {
+  public String asString() {
     return base64EncoderWithoutPadding.encodeToString(ecPoint.getEncoded(false));
   }
 
+  @SuppressWarnings("removal")
+  @Override
+  public String sec1() {
+    return asString();
+  }
+
+  @Override
+  public String asShortString() {
+    return base64EncoderWithoutPadding.encodeToString(ecPoint.getEncoded(true));
+  }
+
+  @SuppressWarnings("removal")
   @Override
   public String sec1Compressed() {
-    return base64EncoderWithoutPadding.encodeToString(ecPoint.getEncoded(true));
+    return asShortString();
   }
 
   @Override

--- a/src/main/java/be/smals/shared/pseudo/helper/internal/ValueImpl.java
+++ b/src/main/java/be/smals/shared/pseudo/helper/internal/ValueImpl.java
@@ -46,7 +46,7 @@ public final class ValueImpl extends PseudonymImpl implements Value {
   @Override
   public CompletableFuture<PseudonymInTransitImpl> pseudonymize() {
     final var random = domain.createRandom();
-    final var blindedValue = new PseudonymImpl(ecPoint.multiply(random).normalize(), domain);
+    final var blindedValue = multiply(random);
     final var payload = domain.createPayloadString(blindedValue);
     final var pseudonymInTransitFactory = domain.pseudonymInTransitFactory();
     return domain.pseudonymisationClient().pseudonymize(domain.key(), payload)


### PR DESCRIPTION
Make `PseudonymInTransit` extend `Point` instead of `Pseudonym`.
Also move `x()` and `y()` methods into the `Point`.